### PR TITLE
More informative time metrics

### DIFF
--- a/curl-format.txt
+++ b/curl-format.txt
@@ -28,13 +28,12 @@
 \n
 ===  TIME BREAKDOWN:  ==========\n
 \n
-    time_appconnect:  %{time_appconnect}\n
-    time_TCPconnect:  %{time_connect}\n
-     time_DNSlookup:  %{time_namelookup}\n
-   time_pretransfer:  %{time_pretransfer}\n
- time_starttransfer:  %{time_starttransfer}\n
-      time_redirect:  %{time_redirect}\n
-          time_TTFB:  %{time_starttransfer}\n
-                      ----------\n
-         time_total:  %{time_total}\n
+    time_dns_lookup:  %{time_namelookup}\n
+ time_tcp_connected:  %{time_connect}\n
+time_handshake_done:  %{time_appconnect}\n
+  time_request_sent:  %{time_pretransfer}\n
+    time_first_byte:  %{time_starttransfer}\n
+    time_downloaded:  %{time_total}\n
+\n
+     time_redirects:  %{time_redirect}\n
 \n


### PR DESCRIPTION
This attemps to make time metrics more useful by:

- sorting them in chronological order (i.e. dns lookup comes first, then tcp_connect, then handshake, etc.)
- giving more informative names to some of them (i.e. `appconnect` → `handshake_done` or `pretransfer` → `request_sent`)
- setting `time_redirect` apart since it'll usually be zero unless `-L` is used, and it's not counted from the start like the rest of the metrics